### PR TITLE
Create ERC4907Upgradeable contract

### DIFF
--- a/contracts/ERC4907Upgradeable.sol
+++ b/contracts/ERC4907Upgradeable.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.17;
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "./IERC4907.sol";
+
+contract ERC4907Upgradeable is Initializable, ERC721Upgradeable, IERC4907 {
+
+    struct UserInfo {
+        address user;   // address of user role
+        uint64 expires; // unix timestamp, user expires
+    }
+
+    mapping (uint256  => UserInfo) internal _users;
+
+    function initialize(string calldata name_, string calldata symbol_) internal onlyInitializing {
+        ERC721Upgradeable.__ERC721_init(name_, symbol_);
+    }
+
+    /// @notice set the user and expires of an NFT
+    /// @dev The zero address indicates there is no user
+    /// Throws if `tokenId` is not valid NFT
+    /// @param user  The new user of the NFT
+    /// @param expires  UNIX timestamp, The new user could use the NFT before expires
+    function setUser(uint256 tokenId, address user, uint64 expires) public virtual {
+        require(_isApprovedOrOwner(msg.sender, tokenId), "ERC4907: transfer caller is not owner nor approved");
+
+        UserInfo storage info =  _users[tokenId];
+
+        info.user = user;
+
+        info.expires = expires;
+
+        emit UpdateUser(tokenId, user, expires);
+    }
+
+    /// @notice Get the user address of an NFT
+    /// @dev The zero address indicates that there is no user or the user is expired
+    /// @param tokenId The NFT to get the user address for
+    /// @return The user address for this NFT
+    function userOf(uint256 tokenId) public view virtual returns(address) {
+        if( uint256(_users[tokenId].expires) >=  block.timestamp) {
+            return  _users[tokenId].user;
+        } else {
+            return address(0);
+        }
+    }
+
+    /// @notice Get the user expires of an NFT
+    /// @dev The zero value indicates that there is no user
+    /// @param tokenId The NFT to get the user expires for
+    /// @return The user expires for this NFT
+    function userExpires(uint256 tokenId) public view virtual returns(uint256) {
+        return _users[tokenId].expires;
+    }
+
+    /// @dev See {IERC165-supportsInterface}.
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IERC4907).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    function _beforeTokenTransfer(address from, address to, uint256 tokenId) internal virtual {
+        super._beforeTokenTransfer(from, to, tokenId, 1);
+
+        if (from != to && _users[tokenId].user != address(0)) {
+            delete _users[tokenId];
+
+            emit UpdateUser(tokenId, address(0), 0);
+        }
+    }
+}

--- a/contracts/ERC4907Upgradeable.sol
+++ b/contracts/ERC4907Upgradeable.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 pragma solidity 0.8.17;
+
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "./IERC4907.sol";
@@ -12,7 +13,7 @@ contract ERC4907Upgradeable is Initializable, ERC721Upgradeable, IERC4907 {
         uint64 expires; // unix timestamp, user expires
     }
 
-    mapping (uint256  => UserInfo) internal _users;
+    mapping(uint256 => UserInfo) internal _users;
 
     function initialize(string calldata name_, string calldata symbol_) internal onlyInitializing {
         ERC721Upgradeable.__ERC721_init(name_, symbol_);
@@ -26,7 +27,7 @@ contract ERC4907Upgradeable is Initializable, ERC721Upgradeable, IERC4907 {
     function setUser(uint256 tokenId, address user, uint64 expires) public virtual {
         require(_isApprovedOrOwner(msg.sender, tokenId), "ERC4907: transfer caller is not owner nor approved");
 
-        UserInfo storage info =  _users[tokenId];
+        UserInfo storage info = _users[tokenId];
 
         info.user = user;
 
@@ -39,9 +40,9 @@ contract ERC4907Upgradeable is Initializable, ERC721Upgradeable, IERC4907 {
     /// @dev The zero address indicates that there is no user or the user is expired
     /// @param tokenId The NFT to get the user address for
     /// @return The user address for this NFT
-    function userOf(uint256 tokenId) public view virtual returns(address) {
-        if( uint256(_users[tokenId].expires) >=  block.timestamp) {
-            return  _users[tokenId].user;
+    function userOf(uint256 tokenId) public view virtual returns (address) {
+        if (uint256(_users[tokenId].expires) >= block.timestamp) {
+            return _users[tokenId].user;
         } else {
             return address(0);
         }
@@ -51,7 +52,7 @@ contract ERC4907Upgradeable is Initializable, ERC721Upgradeable, IERC4907 {
     /// @dev The zero value indicates that there is no user
     /// @param tokenId The NFT to get the user expires for
     /// @return The user expires for this NFT
-    function userExpires(uint256 tokenId) public view virtual returns(uint256) {
+    function userExpires(uint256 tokenId) public view virtual returns (uint256) {
         return _users[tokenId].expires;
     }
 


### PR DESCRIPTION
Create ERC4907Upgradeable from ERC721Upgradeable OpenZepellin contract and official implementation of ERC4907.

https://eips.ethereum.org/EIPS/eip-4907#contract-interface
 

